### PR TITLE
Add Azure Service Bus integration for email sending

### DIFF
--- a/ECommerceApi.csproj
+++ b/ECommerceApi.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
     <PackageReference Include="NSwag.AspNetCore" Version="14.1.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.2.0" />
   </ItemGroup>
 
 </Project>

--- a/EmailService.cs
+++ b/EmailService.cs
@@ -1,6 +1,16 @@
+using Microsoft.Azure.ServiceBus;
+using System.Text;
+using System.Text.Json;
 
 public class EmailService : IEmailService
 {
+    private readonly QueueClient _queueClient;
+
+    public EmailService(QueueClient queueClient)
+    {
+        _queueClient = queueClient;
+    }
+
     public async Task<Email> GetEmail(Guid id)
     {
         throw new NotImplementedException();
@@ -13,7 +23,10 @@ public class EmailService : IEmailService
                                     sendEmailRequest.Subject,
                                     sendEmailRequest.Body);
 
-        await Task.Delay(new Random().Next(0, 5000));
+        var messageBody = JsonSerializer.Serialize(sendEmailRequest);
+        var message = new Message(Encoding.UTF8.GetBytes(messageBody));
+
+        await _queueClient.SendAsync(message);
 
         return emailItem;
     }

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,15 @@
 using NSwag.AspNetCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Azure.ServiceBus;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
 builder.Services.AddScoped<IEmailService, EmailService>();
+
+var serviceBusConnectionString = builder.Configuration.GetValue<string>("AzureServiceBus:ConnectionString");
+var queueClient = new QueueClient(serviceBusConnectionString, "emailqueue");
+builder.Services.AddSingleton(queueClient);
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddOpenApiDocument(config =>

--- a/appsettings.json
+++ b/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AzureServiceBus": {
+    "ConnectionString": "your-azure-service-bus-connection-string"
+  }
 }


### PR DESCRIPTION
Add Azure Service Bus integration for sending email requests.

* Add `Microsoft.Azure.ServiceBus` package reference to `ECommerceApi.csproj`.
* Add Azure Service Bus connection string configuration to `appsettings.json`.
* Add `Microsoft.Azure.ServiceBus` namespace import and `QueueClient` field to `EmailService.cs`.
* Modify `SendEmail` method in `EmailService.cs` to send `SendEmailRequest` to Azure Service Bus queue.
* Add Azure Service Bus connection string configuration and register `QueueClient` as a singleton service in `Program.cs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fkucuk/ECommerceApi/pull/1?shareId=d906602e-19d2-478c-92cc-ce09d978d87b).